### PR TITLE
Run code in controllers directory

### DIFF
--- a/ajusteWithNoLock.js
+++ b/ajusteWithNoLock.js
@@ -1,5 +1,6 @@
 const fs = require('fs').promises;
 const path = require('path');
+const { processTextWithEmbeddedSql } = require('./sql-nolock-cli/src/processor');
 
 const ROOT_DIR = 'C:\\Sites\\sistema-contel\\conteltelecom\\CRON';
 const EXTENSOES_VALIDAS = ['.vb', '.js', '.aspx.vb'];
@@ -28,51 +29,32 @@ async function listarArquivos(dir) {
   return arquivos;
 }
 
-async function corrigirFromEJoinSemNoLock() {
+async function corrigirWithNoLockEmStringsSql() {
   const arquivos = await listarArquivos(ROOT_DIR);
-  let totalFromCorrigidos = 0;
-  let totalJoinCorrigidos = 0;
-
-  // Regex mais seguro com \b para fim de palavra
-  const regexFromSemNoLock = /FROM\s+([a-zA-Z0-9_\[\]\.]+)\b(?!\s+WITH\s*\(NOLOCK\))/gi;
-
-  // JOIN <tabela> com ON — sem NOLOCK no meio
-  const regexJoinSemNoLock = /JOIN\s+([a-zA-Z0-9_\[\]\.]+)\b(?!\s+WITH\s*\(NOLOCK\))(?=\s+ON\b)/gi;
+  let totalArquivosAlterados = 0;
+  let totalSelectsAlterados = 0;
+  let totalTabelasAlteradas = 0;
 
   for (const arquivo of arquivos) {
     try {
-      let conteudo = await fs.readFile(arquivo, 'utf-8');
-      let atualizado = false;
-
-      // Corrige FROM
-      const fromMatch = conteudo.match(regexFromSemNoLock);
-      if (fromMatch) {
-        conteudo = conteudo.replace(regexFromSemNoLock, 'FROM $1 WITH (NOLOCK)');
-        totalFromCorrigidos += fromMatch.length;
-        atualizado = true;
+      const conteudo = await fs.readFile(arquivo, 'utf-8');
+      const { result, statementsChanged, tablesChanged } = processTextWithEmbeddedSql(conteudo);
+      if (result !== conteudo) {
+        await fs.writeFile(arquivo, result, 'utf-8');
+        totalArquivosAlterados += 1;
+        totalSelectsAlterados += statementsChanged;
+        totalTabelasAlteradas += tablesChanged;
+        console.log(`✅ Corrigido: ${arquivo} (${tablesChanged} tabelas em ${statementsChanged} SELECTs)`);
       }
-
-      // Corrige JOIN
-      const joinMatch = conteudo.match(regexJoinSemNoLock);
-      if (joinMatch) {
-        conteudo = conteudo.replace(regexJoinSemNoLock, 'JOIN $1 WITH (NOLOCK)');
-        totalJoinCorrigidos += joinMatch.length;
-        atualizado = true;
-      }
-
-      if (atualizado) {
-        await fs.writeFile(arquivo, conteudo, 'utf-8');
-        console.log(`✅ Corrigido: ${arquivo}`);
-      }
-
     } catch (err) {
       console.warn(`Erro ao processar ${arquivo}: ${err.message}`);
     }
   }
 
   console.log(`\n🛠️ Correções aplicadas:`);
-  console.log(`- FROM sem NOLOCK: ${totalFromCorrigidos}`);
-  console.log(`- JOIN sem NOLOCK: ${totalJoinCorrigidos}`);
+  console.log(`- Arquivos alterados: ${totalArquivosAlterados}`);
+  console.log(`- Tabelas com NOLOCK inserido/ajustado: ${totalTabelasAlteradas}`);
+  console.log(`- SELECTs impactados: ${totalSelectsAlterados}`);
 }
 
-corrigirFromEJoinSemNoLock();
+corrigirWithNoLockEmStringsSql();


### PR DESCRIPTION
Refactors SQL `WITH (NOLOCK)` insertion logic to prevent duplication and ensure correct placement after table aliases.

Previously, the `WITH (NOLOCK)` clause could be duplicated or incorrectly placed before a table alias. This change introduces robust SQL parsing to detect existing `WITH` clauses, move them after aliases if they appear before, and add `NOLOCK` only if missing, ensuring SQL syntax correctness.

---
<a href="https://cursor.com/background-agent?bcId=bc-59a5d6da-aad6-4a77-9389-ec12216d8197">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-59a5d6da-aad6-4a77-9389-ec12216d8197">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

